### PR TITLE
テキストが行ボックスから溢れないようにする

### DIFF
--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -17,6 +17,7 @@ body {
   background-color: #000;
   color: #ccc;
   overflow-y: scroll;
+  overflow-wrap: break-word;
 }
 
 *,
@@ -80,7 +81,6 @@ ul {
   margin: 0 auto;
   padding: 1rem;
 }
-
 
 .footer {
   padding: 1rem;
@@ -154,7 +154,6 @@ ul {
     }
   }
 }
-
 
 .article-body {
   margin-top: 3rem;


### PR DESCRIPTION
記事中に表示されている長いURLが改行されずにボックスをはみ出してしまっていたので修正しました！

![](https://user-images.githubusercontent.com/11547305/90456493-0fed9980-e134-11ea-9d94-a6e69acf4d5e.png)
